### PR TITLE
Add config option to silence launch notification

### DIFF
--- a/LinConnectServer/main/linconnect_server.py
+++ b/LinConnectServer/main/linconnect_server.py
@@ -90,7 +90,7 @@ except IOError:
         "notify_start":1,
     }
     with open(conf_file, 'w') as text_file:
-        conf.write(conf_file)
+        conf.write(text_file)
 
 parser = ConfigParser.ConfigParser()
 parser.read(conf_file)

--- a/LinConnectServer/main/linconnect_server.py
+++ b/LinConnectServer/main/linconnect_server.py
@@ -79,16 +79,18 @@ try:
         print("Loading conf.ini")
 except IOError:
     print("Creating conf.ini")
+
     conf = ConfigParser.ConfigParser()
-    conf["connection"] = {
-        "port":9090,
-        "enable_bonjour":1,
-    }
-    conf["other"] = {
-        "enable_instruction_webpage":1,
-        "notify_timeout":5000,
-        "notify_start":1,
-    }
+
+    conf.add_section("connection")
+    conf.set("connection", "port", 9090)
+    conf.set("connection", "enable_bonjour", 1)
+
+    conf.add_section("other")
+    conf.set("other", "enable_instruction_webpage", 1)
+    conf.set("other", "notify_timeout", 5000)
+    conf.set("other", "notify_start", 1)
+
     with open(conf_file, 'w') as text_file:
         conf.write(text_file)
 


### PR DESCRIPTION
For my own installation I had commented out the launch notification lines because I didn't want to see the notification every time. Here I've added it as a config option initially set to true to keep the same behaviour as previously by default, and changed the config file creation to use configparser while I was at it.